### PR TITLE
[Form Element] Add percent to setName regex

### DIFF
--- a/src/B8Framework/Form/Element.php
+++ b/src/B8Framework/Form/Element.php
@@ -28,7 +28,7 @@ abstract class Element
 
     public function setName($name)
     {
-        $this->_name = strtolower(preg_replace('/([^a-zA-Z0-9_\-])/', '', $name));
+        $this->_name = strtolower(preg_replace('/([^a-zA-Z0-9_\-%])/', '', $name));
         return $this;
     }
 


### PR DESCRIPTION
According to [RFC](https://tools.ietf.org/html/rfc3986#section-3.4). This is not full fix, but it allows you to use percent encoded symbols for e.g. arrays in get queries(it's critical and common usage). If it is important, It can be changed and added by another allowed symbols from RFC.