### PR TITLE
fix Uncaught ReferenceError: moment is not defined

### DIFF
--- a/src/PHPCensor/View/layout.phtml
+++ b/src/PHPCensor/View/layout.phtml
@@ -246,6 +246,7 @@
     </aside><!-- /.content-wrapper -->
 </div><!-- ./wrapper -->
 
+<script src="<?php print APP_URL; ?>assets/vendor/moment/min/moment.min.js" type="text/javascript"></script>
 <script src="<?php print APP_URL; ?>assets/vendor/admin-lte/plugins/jQueryUI/jquery-ui.min.js" type="text/javascript"></script>
 <script src="<?php print APP_URL; ?>assets/vendor/admin-lte/bootstrap/js/bootstrap.min.js" type="text/javascript"></script>
 


### PR DESCRIPTION
daterangepicker.js requires moment.js but it was not included in layout.phtml