### PR TITLE
Fix build execute - in some cases one build executed with many process

### DIFF
--- a/src/PHPCensor/Builder.php
+++ b/src/PHPCensor/Builder.php
@@ -175,8 +175,16 @@ class Builder implements LoggerAwareInterface
      */
     public function execute()
     {
+        // check current status
+        if ($this->build->getStatus() != Build::STATUS_PENDING) {
+            throw new BuilderException('Can`t build - status is not pending', BuilderException::FAIL_START);
+        }
+        // set status only if current status pending
+        if (!$this->build->setStatusSync(Build::STATUS_RUNNING)) {
+            throw new BuilderException('Can`t build - unable change status to running', BuilderException::FAIL_START);
+        }
+
         // Update the build in the database, ping any external services.
-        $this->build->setStatus(Build::STATUS_RUNNING);
         $this->build->setStarted(new \DateTime());
         $this->store->save($this->build);
         $this->build->sendStatusPostback();

--- a/src/PHPCensor/BuilderException.php
+++ b/src/PHPCensor/BuilderException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace PHPCensor;
+
+class BuilderException extends \Exception {
+    /** Fail start build - non fatal */
+    const FAIL_START = 1;
+}

--- a/src/PHPCensor/Model/Build.php
+++ b/src/PHPCensor/Model/Build.php
@@ -411,6 +411,27 @@ class Build extends Model
     }
 
     /**
+     * Set the value of Status / status only if it synced with db. Must not be null.
+     *
+     * @param $value int
+     * @return bool
+     */
+    public function setStatusSync($value)
+    {
+        $this->validateNotNull('Status', $value);
+        $this->validateInt('Status', $value);
+
+        if ($this->data['status'] !== $value) {
+            $store = Factory::getStore('Build');
+            if ($store->updateStatusSync($this, $value)) {
+                $this->data['status'] = $value;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Set the value of Log / log.
      *
      * @param $value string

--- a/src/PHPCensor/Store/BuildStore.php
+++ b/src/PHPCensor/Store/BuildStore.php
@@ -310,4 +310,24 @@ class BuildStore extends Store
             return false;
         }
     }
+
+    /**
+     * Update status only if it synced with db
+     * @param Build $build
+     * @param int $status
+     * @return bool
+     */
+    public function updateStatusSync($build, $status)
+    {
+        try {
+            $query = 'UPDATE {{build}} SET status = :status_new WHERE {{id}} = :id AND {{status}} = :status_current';
+            $stmt = Database::getConnection('write')->prepareCommon($query);
+            $stmt->bindValue(':id', $build->getId(), \PDO::PARAM_INT);
+            $stmt->bindValue(':status_current', $build->getStatus(), \PDO::PARAM_INT);
+            $stmt->bindValue(':status_new', $status, \PDO::PARAM_INT);
+            return ($stmt->execute() and ($stmt->rowCount() == 1));
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
 }

--- a/src/PHPCensor/Worker/BuildWorker.php
+++ b/src/PHPCensor/Worker/BuildWorker.php
@@ -126,6 +126,7 @@ class BuildWorker
                     case BuilderException::FAIL_START:
                         // non fatal
                         $this->pheanstalk->release($job);
+                        unset($job);
                         break;
                     default:
                         $build->setStatus(Build::STATUS_FAILED);
@@ -140,6 +141,7 @@ class BuildWorker
                 // connection or similar. Release the job and kill the worker.
                 $this->run = false;
                 $this->pheanstalk->release($job);
+                unset($job);
             } catch (\Exception $ex) {
                 $build->setStatus(Build::STATUS_FAILED);
                 $build->setFinished(new \DateTime());
@@ -160,7 +162,9 @@ class BuildWorker
             }
 
             // Delete the job when we're done:
-            $this->pheanstalk->delete($job);
+            if (!empty($job)) {
+                $this->pheanstalk->delete($job);
+            }
         }
     }
 

--- a/src/PHPCensor/Worker/BuildWorker.php
+++ b/src/PHPCensor/Worker/BuildWorker.php
@@ -108,6 +108,7 @@ class BuildWorker
             } catch (\Exception $ex) {
                 $this->logger->addWarning('Build #' . $jobData['build_id'] . ' does not exist in the database.');
                 $this->pheanstalk->delete($job);
+                continue;
             }
 
             // Logging relevant to this build should be stored
@@ -130,7 +131,7 @@ class BuildWorker
                         $build->setStatus(Build::STATUS_FAILED);
                         $build->setFinished(new \DateTime());
                         $build->setLog($build->getLog() . PHP_EOL . PHP_EOL . $ex->getMessage());
-                        $store->save($build);
+                        $buildStore->save($build);
                         $build->sendStatusPostback();
                         break;
                 }


### PR DESCRIPTION
This fix is mainly for run builds with crontab. But probably this can be useful for run builds with workers.
Ideally, need rewrite the build execution code with lock, check process id, etc.
This fix use sql update status with condition to prevent concurrent processes acquire same build (I saw up to 5 parallel executions one build - if build execution time bigger than crontab schedule period). Also an attempt to correct the wrong work with the loggers in case of failures (the release of the build log was not performed). And the wrong check for the running build of a project.
It is necessary to test the build with workers.