### PR TITLE
Fix Technical Debt Plugin configuration parameters

### DIFF
--- a/docs/en/plugins/technical_dept.md
+++ b/docs/en/plugins/technical_dept.md
@@ -7,5 +7,8 @@ Configuration
 -------------
 
 ### Options
-
-* **searches** - Optional - Case-insensitive array of terms to search for. Defaults to TODO, TO DO, FIXME and FIX ME.
+* **allowed_errors** [int, optional] - The error limit for a successful build (default: 0). -1 disables errors. Setting allowed_errors in conjunction with zero_config will override zero_config.
+* **suffixes** [array, optional] - An array of file extensions to check (default: 'php')
+* **directory** [string, optional] - directory to inspect (default: build root)
+* **ignore** [array, optional] - directory to ignore (default: inherits ignores specified in setup)
+* **searches** [array, optional] - Optional - Case-insensitive array of terms to search for. Defaults to TODO, TO DO, FIXME and FIX ME.

--- a/src/PHPCensor/Plugin/TechnicalDebt.php
+++ b/src/PHPCensor/Plugin/TechnicalDebt.php
@@ -75,6 +75,21 @@ class TechnicalDebt extends Plugin implements ZeroConfigPluginInterface
         if (isset($options['zero_config']) && $options['zero_config']) {
             $this->allowed_errors = -1;
         }
+
+        $this->setOptions($options);
+    }
+
+    /**
+     * Handle this plugin's options.
+     * @param $options
+     */
+    protected function setOptions($options)
+    {
+        foreach (array('directory', 'path', 'ignore', 'allowed_errors') as $key) {
+            if (array_key_exists($key, $options)) {
+                $this->{$key} = $options[$key];
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Return Technical Debt Plugin parameters initialisation.
Return Technical Debt Plugin missing parameters description to docs.

Actually just an exact copy-paste from PHPCI.