### PR TITLE
Remove copy-paste from phpcpd plugin docs :)

### DIFF
--- a/docs/en/plugins/php_cpd.md
+++ b/docs/en/plugins/php_cpd.md
@@ -10,14 +10,12 @@ Configuration
 
 * **path** - Optional - Path in which to run PHP Copy/Paste Detector (default: build root).
 * **ignore** - Optional - A list of files / paths to ignore (default: build_settings > ignore).
-* **standard** [string, optional] - which PSR standard to follow (default: 'PSR1').
 
 ### Examples
 
 ```yml
 test:
   php_cpd:
-    standard: "PSR2"
     path: "app"
     ignore:
       - "app/my/path"


### PR DESCRIPTION
The 'standard' option is unused in the PhpCpd plugin, and does not actually make sense for copy-paste-detection.