### PR TITLE
display build branch instead of project branch in Home/index and ajax-timeline

### DIFF
--- a/src/PHPCensor/View/Home/ajax-timeline.phtml
+++ b/src/PHPCensor/View/Home/ajax-timeline.phtml
@@ -1,6 +1,6 @@
-<?php 
+<?php
 
-use PHPCensor\Helper\Lang; 
+use PHPCensor\Helper\Lang;
 use PHPCensor\Model\Build;
 
 ?>
@@ -78,7 +78,7 @@ use PHPCensor\Model\Build;
                 </h3>
 
                 <div class="timeline-body">
-                    <a href="<?php echo $build->getBranchLink();?>"><?php echo $build->getProject()->getBranch(); ?></a>
+                    <a href="<?php echo $build->getBranchLink();?>"><?php echo $build->getBranch(); ?></a>
                     <?php print $branches ? ' + '.implode(', ', $branches) : ''; ?> -
                     <?php
                     if ($build->getCommitId() !== 'Manual') {

--- a/src/PHPCensor/View/Home/index.phtml
+++ b/src/PHPCensor/View/Home/index.phtml
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 use PHPCensor\Helper\Lang;
 use PHPCensor\Model\Build;
@@ -109,7 +109,7 @@ use PHPCensor\Model\Build;
                                 </h3>
 
                                 <div class="timeline-body">
-                                    <a href="<?php echo $build->getBranchLink();?>"><?php echo $build->getProject()->getBranch(); ?></a>
+                                    <a href="<?php echo $build->getBranchLink();?>"><?php echo $build->getBranch(); ?></a>
                                     <?php print $branches ? ' + '.implode(', ', $branches) : ''; ?> -
                                     <?php
                                     if ($build->getCommitId() !== 'Manual') {


### PR DESCRIPTION
Branches in Dashboard->Timeline were always the ones in project settings (Default branch name).

This PR makes sure build branch is displayed, just like it is in build details view.

Thanks.