### PR TITLE
Fixed GitHub status API and access to the pull requests of private projects

### DIFF
--- a/src/PHPCensor/Model/Build/MercurialBuild.php
+++ b/src/PHPCensor/Model/Build/MercurialBuild.php
@@ -79,9 +79,10 @@ class MercurialBuild extends Build
      * Handle post-clone tasks (switching branch, etc.)
      * @param Builder $builder
      * @param $cloneTo
+     * @param array $extra
      * @return bool
      */
-    protected function postCloneSetup(Builder $builder, $cloneTo)
+    protected function postCloneSetup(Builder $builder, $cloneTo, array $extra = null)
     {
         $success = true;
         $commit = $this->getCommitId();

--- a/src/PHPCensor/Model/Build/RemoteGitBuild.php
+++ b/src/PHPCensor/Model/Build/RemoteGitBuild.php
@@ -114,7 +114,11 @@ class RemoteGitBuild extends Build
         $success = $builder->executeCommand($cmd, $this->getBranch(), $this->getCloneUrl(), $cloneTo);
 
         if ($success) {
-            $success = $this->postCloneSetup($builder, $cloneTo);
+            $extra = [
+                'git_ssh_wrapper' => $gitSshWrapper
+            ];
+
+            $success = $this->postCloneSetup($builder, $cloneTo, $extra);
         }
 
         // Remove the key file and git wrapper:
@@ -128,9 +132,10 @@ class RemoteGitBuild extends Build
      * Handle any post-clone tasks, like switching branches.
      * @param Builder $builder
      * @param $cloneTo
+     * @param array $extra
      * @return bool
      */
-    protected function postCloneSetup(Builder $builder, $cloneTo)
+    protected function postCloneSetup(Builder $builder, $cloneTo, array $extra = null)
     {
         $success = true;
         $commit  = $this->getCommitId();


### PR DESCRIPTION
There are two fixes for GitHub-hosted repositories:

1. There was a typo due to which the status API was broken ob GitHub (https://github.com/corpsee/php-censor/commit/31f92327c12e0cfdb1754650455a9aabc3973924#diff-7e0d0931800d0b6846f60da0d2b19cd6)
2. When working with PR on GitHub the repository is downloaded in a special way:
- At first, the main project's repository is downloaded
- Then a new branch is created with the changes from PR, which are located in the forked repository.

If both of these projects (original and fork) are private, then they should be downloaded using a ssh-key. The issue was that when downloading the fork, this ssh-key was not used.
Therefore it worked with public repositories, but did not work with private ones.