### PR TITLE
Fixed ability to fetch private pull requests on Github

### DIFF
--- a/src/PHPCensor/Model/Build/GithubBuild.php
+++ b/src/PHPCensor/Model/Build/GithubBuild.php
@@ -174,14 +174,14 @@ class GithubBuild extends RemoteGitBuild
 
         try {
             if (!empty($buildType) && $buildType == 'pull_request') {
-                $remoteUrl = $this->getExtra('remote_url');
-                $remoteBranch = $this->getExtra('remote_branch');
+                $pullRequestId = $this->getExtra('pull_request_number');
 
-                $cmd = 'cd "%s" && git checkout -b php-censor/' . $this->getId() . ' %s && git pull -q --no-edit %s %s';
+                $cmd = 'cd "%s" && git checkout -b php-censor/' . $this->getId()
+                    . ' %s && git pull -q --no-edit origin pull/%s/head';
                 if (!empty($extra['git_ssh_wrapper'])) {
                     $cmd = 'export GIT_SSH="'.$extra['git_ssh_wrapper'].'" && ' . $cmd;
                 }
-                $success = $builder->executeCommand($cmd, $cloneTo, $this->getBranch(), $remoteUrl, $remoteBranch);
+                $success = $builder->executeCommand($cmd, $cloneTo, $this->getBranch(), $pullRequestId);
             }
         } catch (\Exception $ex) {
             $success = false;


### PR DESCRIPTION
With this change I added support of `refs/pull` on Github (https://help.github.com/articles/checking-out-pull-requests-locally/).
After this change this scheme will work:
- Organization "Company" has a private repository "Project"
- Mike has read-only access to this repository
- John has access to merge pull requests
- To make some changes in this project Mike creates a Fork of this repository. Then he commit his changes and creates a new Pull Request
- John could view this Pull Request on the original Project's repository (via the Web), but he cannot view the Fork of Mike, because this project is private
- But Github gives us ability to fetch changes from this PR as an external reference on the main repository (`refs/pull/1/head`)