### PR TITLE
build directory is shown as ./ in log output

### DIFF
--- a/src/PHPCensor/Logging/BuildDBLogHandler.php
+++ b/src/PHPCensor/Logging/BuildDBLogHandler.php
@@ -70,7 +70,7 @@ class BuildDBLogHandler extends AbstractProcessingHandler
     protected function write(array $record)
     {
         $message = (string)$record['message'];
-        $message = str_replace($this->build->currentBuildPath, '/', $message);
+        $message = str_replace($this->build->currentBuildPath, './', $message);
 
         $this->logValue .= $message . PHP_EOL;
 


### PR DESCRIPTION
It was shown as "/", which is irritating because it looks like root directory.