### PR TITLE
Bitbucket build status API, create comments on commits and Pull Requests

### DIFF
--- a/docs/en/configuring.md
+++ b/docs/en/configuring.md
@@ -36,6 +36,12 @@ php-censor:
     host:      localhost
     name:      php-censor-queue
     lifetime:  600
+  bitbucket:
+    username: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    app_password: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+    comments:
+      commit:       false # This option allow/deny to post comments to Bitbucket commit
+      pull_request: false # This option allow/deny to post comments to Bitbucket Pull Request
   github:
     token: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
     comments:

--- a/src/PHPCensor/Command/InstallCommand.php
+++ b/src/PHPCensor/Command/InstallCommand.php
@@ -261,6 +261,14 @@ class InstallCommand extends Command
                 'smtp_password'          => null,
                 'smtp_encryption'        => false,
             ],
+            'bitbucket'   => [
+                'username'     => null,
+                'app_password' => null,
+                'comments' => [
+                    'commit'       => false,
+                    'pull_request' => false,
+                ],
+            ],
             'github'   => [
                 'token'    => null,
                 'comments' => [

--- a/src/PHPCensor/Helper/Bitbucket.php
+++ b/src/PHPCensor/Helper/Bitbucket.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace PHPCensor\Helper;
+
+use b8\Config;
+use GuzzleHttp\Client;
+
+/**
+ * The Bitbucket Helper class provides some Bitbucket API call functionality.
+ */
+class Bitbucket
+{
+    /**
+     * Create a comment on a specific file (and commit) in a Bitbucket Pull Request.
+     *
+     * @param string $repo
+     * @param int $pullId
+     * @param string $commitId
+     * @param string $file
+     * @param int $line
+     * @param string $comment
+     *
+     * @return null
+     */
+    public function createPullRequestComment($repo, $pullId, $commitId, $file, $line, $comment)
+    {
+        $username = Config::getInstance()->get('php-censor.bitbucket.username');
+        $appPassword = Config::getInstance()->get('php-censor.bitbucket.app_password');
+
+        if (empty($username) || empty($appPassword)) {
+            return;
+        }
+
+        $url = '/1.0/repositories/' . $repo . '/pullrequests/' . $pullId . '/comments/';
+        $client = new Client(['base_uri' => 'https://api.bitbucket.org']);
+        $response = $client->post($url, [
+            'auth'      => [$username, $appPassword],
+            'headers'   => [
+                'Content-Type' => 'application/json',
+            ],
+            'json'      => [
+                'content'   => $comment,
+                'anchor'    => substr($commitId, 0, 12),
+                'filename'  => $file,
+                'line_to'   => $line,
+            ],
+        ]);
+    }
+
+    /**
+     * Create a comment on a Bitbucket commit.
+     *
+     * @param $repo
+     * @param $commitId
+     * @param $file
+     * @param $line
+     * @param $comment
+     * @return null
+     */
+    public function createCommitComment($repo, $commitId, $file, $line, $comment)
+    {
+        $username = Config::getInstance()->get('php-censor.bitbucket.username');
+        $appPassword = Config::getInstance()->get('php-censor.bitbucket.app_password');
+
+        if (empty($username) || empty($appPassword)) {
+            return;
+        }
+
+        $url = '/1.0/repositories/' . $repo . '/changesets/' . $commitId . '/comments';
+
+        $client = new Client(['base_uri' => 'https://api.bitbucket.org']);
+        $response = $client->post($url, [
+            'auth'      => [$username, $appPassword],
+            'headers'   => [
+                'Content-Type' => 'application/json',
+            ],
+            'json'      => [
+                'content'   => $comment,
+                'filename'  => $file,
+                'line_to'   => $line,
+            ],
+        ]);
+    }
+
+    /**
+     * @param string $repo
+     * @param int $pullRequestId
+     *
+     * @return string
+     */
+    public function getPullRequestDiff($repo, $pullRequestId)
+    {
+        $username = Config::getInstance()->get('php-censor.bitbucket.username');
+        $appPassword = Config::getInstance()->get('php-censor.bitbucket.app_password');
+
+        if (empty($username) || empty($appPassword)) {
+            return;
+        }
+
+        $url = '/2.0/repositories/' . $repo . '/pullrequests/' . $pullRequestId . '/diff';
+
+        $client = new Client(['base_uri' => 'https://api.bitbucket.org']);
+
+        $response = $client->get($url, ['auth' => [$username, $appPassword]]);
+
+        return (string)$response->getBody();
+    }
+}

--- a/src/PHPCensor/Model/Build/BitbucketBuild.php
+++ b/src/PHPCensor/Model/Build/BitbucketBuild.php
@@ -2,6 +2,13 @@
 
 namespace PHPCensor\Model\Build;
 
+use GuzzleHttp\Client;
+use PHPCensor\Builder;
+use PHPCensor\Helper\Bitbucket;
+use PHPCensor\Helper\Diff;
+use b8\Config;
+use PHPCensor\Model\BuildError;
+
 /**
  * BitBucket Build Model
  * 
@@ -23,6 +30,91 @@ class BitbucketBuild extends RemoteGitBuild
     public function getBranchLink()
     {
         return 'https://bitbucket.org/' . $this->getProject()->getReference() . '/src/?at=' . $this->getBranch();
+    }
+
+    /**
+     * Get link to tag from another source (i.e. BitBucket)
+     */
+    public function getTagLink()
+    {
+        return 'https://bitbucket.org/' . $this->getProject()->getReference() . '/src/?at=' . $this->getTag();
+    }
+
+    /**
+     * Send status updates to any relevant third parties (i.e. Bitbucket)
+     *
+     * @return bool
+     */
+    public function sendStatusPostback()
+    {
+        if ('Manual' === $this->getCommitId()) {
+            return false;
+        }
+
+        $project    = $this->getProject();
+
+        if (empty($project)) {
+            return false;
+        }
+
+        $username = Config::getInstance()->get('php-censor.bitbucket.username');
+        $appPassword = Config::getInstance()->get('php-censor.bitbucket.app_password');
+
+        if (empty($username) || empty($appPassword) || empty($this->data['id'])) {
+            return false;
+        }
+
+        switch ($this->getStatus()) {
+            case 0:
+            case 1:
+                $status = 'INPROGRESS';
+                $description = 'PHP Censor build running.';
+                break;
+            case 2:
+                $status = 'SUCCESSFUL';
+                $description = 'PHP Censor build passed.';
+                break;
+            case 3:
+                $status = 'FAILED';
+                $description = 'PHP Censor build failed.';
+                break;
+            default:
+                $status = 'STOPPED';
+                $description = 'PHP Censor build failed to complete.';
+                break;
+        }
+
+        $phpCensorUrl = Config::getInstance()->get('php-censor.url');
+
+        $url    = sprintf(
+            '/2.0/repositories/%s/commit/%s/statuses/build',
+            $this->getExtra('build_type') == 'pull_request'
+                ? $this->getExtra('remote_reference')
+                : $project->getReference(),
+            $this->getCommitId()
+        );
+
+        $client = new Client([
+            'base_uri' => 'https://api.bitbucket.org',
+            'http_errors' => false,
+        ]);
+        $response = $client->post($url, [
+            'auth'      => [$username, $appPassword],
+            'headers'   => [
+                'Content-Type' => 'application/json',
+            ],
+            'json'      => [
+                'state'       => $status,
+                'key'         => 'PHP-CENSOR',
+                'url'         => $phpCensorUrl . '/build/view/' . $this->getId(),
+                'name'        => 'PHP Censor Build #' . $this->getId(),
+                'description' => $description,
+            ],
+        ]);
+
+        $status = (integer)$response->getStatusCode();
+
+        return ($status >= 200 && $status < 300);
     }
 
     /**
@@ -49,10 +141,7 @@ class BitbucketBuild extends RemoteGitBuild
         $reference = $this->getProject()->getReference();
 
         if ($this->getExtra('build_type') == 'pull_request') {
-            $matches = [];
-            preg_match('/[\/:]([a-zA-Z0-9_\-]+\/[a-zA-Z0-9_\-]+)/', $this->getExtra('remote_url'), $matches);
-
-            $reference = $matches[1];
+            $reference = $this->getExtra('remote_reference');
         }
 
         $link = 'https://bitbucket.org/' . $reference . '/';
@@ -61,5 +150,139 @@ class BitbucketBuild extends RemoteGitBuild
         $link .= '#{BASEFILE}-{LINE}';
 
         return $link;
+    }
+
+    /**
+     * Handle any post-clone tasks, like applying a pull request patch on top of the branch.
+     * @param Builder $builder
+     * @param $cloneTo
+     * @param array $extra
+     * @return bool
+     */
+    protected function postCloneSetup(Builder $builder, $cloneTo, array $extra = null)
+    {
+        $buildType = $this->getExtra('build_type');
+
+        $success = true;
+        $skipGitFinalization = false;
+
+        try {
+            if (!empty($buildType) && $buildType == 'pull_request') {
+                $helper = new Bitbucket();
+                $diff = $helper->getPullRequestDiff(
+                    $this->getProject()->getReference(),
+                    $this->getExtra('pull_request_number')
+                );
+
+                $diffFile = $this->writeDiff($builder->buildPath, $diff);
+
+                $cmd = 'cd "%s" && git checkout -b php-censor/' . $this->getId() . ' && git apply "%s"';
+
+                $success = $builder->executeCommand($cmd, $cloneTo, $diffFile);
+
+                unlink($diffFile);
+                $skipGitFinalization = true;
+            }
+        } catch (\Exception $ex) {
+            $success = false;
+        }
+
+        if ($success && !$skipGitFinalization) {
+            $success = parent::postCloneSetup($builder, $cloneTo, $extra);
+        }
+
+        return $success;
+    }
+
+    /**
+     * Create an diff file on disk for this build.
+     *
+     * @param  string $cloneTo
+     *
+     * @return string
+     */
+    protected function writeDiff($cloneTo, $diff)
+    {
+        $filePath = dirname($cloneTo . '/temp');
+        $diffFile = $filePath . '.patch';
+
+        file_put_contents($diffFile, $diff);
+        chmod($diffFile, 0600);
+
+        return $diffFile;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function reportError(
+        Builder $builder,
+        $plugin,
+        $message,
+        $severity = BuildError::SEVERITY_NORMAL,
+        $file = null,
+        $lineStart = null,
+        $lineEnd = null
+    ) {
+        $allowCommentCommit      = (boolean)Config::getInstance()->get('php-censor.bitbucket.comments.commit', false);
+        $allowCommentPullRequest = (boolean)Config::getInstance()->get('php-censor.bitbucket.comments.pull_request', false);
+        //$file = $builder->buildPath.'test.php';
+        if ($allowCommentCommit || $allowCommentPullRequest) {
+            $diffLineNumber = $this->getDiffLineNumber($builder, $file, $lineStart);
+
+            if (!is_null($diffLineNumber)) {
+                $helper = new Bitbucket();
+
+                $repo     = $this->getProject()->getReference();
+                $prNumber = $this->getExtra('pull_request_number');
+                $commit   = $this->getCommitId();
+
+                if (!empty($prNumber)) {
+                    if ($allowCommentPullRequest) {
+                        $helper->createPullRequestComment($repo, $prNumber, $commit, $file, $lineStart, $message);
+                    }
+                } else {
+                    if ($allowCommentCommit) {
+                        $helper->createCommitComment($repo, $commit, $file, $lineStart, $message);
+                    }
+                }
+            }
+        }
+
+        parent::reportError($builder, $plugin, $message, $severity, $file, $lineStart, $lineEnd);
+    }
+
+    /**
+     * Uses git diff to figure out what the diff line position is, based on the error line number.
+     * @param Builder $builder
+     * @param $file
+     * @param $line
+     * @return int|null
+     */
+    protected function getDiffLineNumber(Builder $builder, $file, $line)
+    {
+        $line = (integer)$line;
+
+        $builder->logExecOutput(false);
+
+        $prNumber = $this->getExtra('pull_request_number');
+        $path = $builder->buildPath;
+
+        if (!empty($prNumber)) {
+            $builder->executeCommand('cd %s && git diff origin/%s "%s"', $path, $this->getBranch(), $file);
+        } else {
+            $commitId = $this->getCommitId();
+            $compare = $commitId == 'Manual' ? 'HEAD' : $commitId;
+            $builder->executeCommand('cd %s && git diff %s^^ "%s"', $path, $compare, $file);
+        }
+
+        $builder->logExecOutput(true);
+
+        $diff = $builder->getLastOutput();
+
+        $helper = new Diff();
+        $lines = $helper->getLinePositions($diff);
+
+        return isset($lines[$line]) ? $lines[$line] : null;
     }
 }


### PR DESCRIPTION
Added the same functionality as was on the GitHub: build statuses, comments on commits and pull requests, handling webhooks of "pullrequest" event.